### PR TITLE
Add: 슈퍼어드민의 어드민 삭제 및 비밀번호 수정 기능, 로그인 시 리쿠르트아이디 선택적으로 받음

### DIFF
--- a/core/decorators.py
+++ b/core/decorators.py
@@ -54,3 +54,30 @@ def admin_only(func):
             return JsonResponse({'message': 'KEY_ERROR'}, status=400)
 
     return wrapper
+
+def superadmin_only(func):
+    def wrapper(self, request, *args, **kwargs):
+        try:
+            access_token = request.headers.get('Authorization')
+            pay_load     = jwt.decode(access_token, SECRET_KEY, algorithms=[ALGORITHM])
+            role         = pay_load['role']
+            user         = User.objects.get(id=pay_load['user_id'])
+            request.user = user
+            
+            if not role == 'superadmin':
+                return JsonResponse({'message': 'UNAUTHORIZED'}, status=401)
+
+            return func(self, request, *args, **kwargs)
+
+        except jwt.InvalidTokenError:
+            return JsonResponse({'message': 'INVALID_TOKEN'}, status=401)
+        except jwt.exceptions.DecodeError:
+            return JsonResponse({'message': 'DECODE_ERROR'}, status=400)
+        except jwt.ExpiredSignatureError:
+            return JsonResponse({'message': 'EXPIRED_TOKEN'}, status=401)
+        except User.DoesNotExist:
+            return JsonResponse({'message': 'USER_DOES_NOT_EXISTS'}, status=401)
+        except KeyError:
+            return JsonResponse({'message': 'KEY_ERROR'}, status=400)
+
+    return wrapper

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -37,3 +37,7 @@ class SuperadminGetSerializer(serializers.ModelSerializer):
     class Meta:
         model  = User
         fields = ['email', 'created_at', 'updated_at']
+
+class SuperadminPatchSerializer(serializers.Serializer):
+    new_password       = serializers.CharField()
+    new_password_check = serializers.CharField()

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -32,3 +32,8 @@ class ChangePasswordSerializer(serializers.Serializer):
     email        = serializers.EmailField()
     code         = serializers.CharField()
     new_password = serializers.CharField()
+
+class SuperadminGetSerializer(serializers.ModelSerializer):
+    class Meta:
+        model  = User
+        fields = ['email', 'created_at', 'updated_at']

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,12 +1,12 @@
 from django.urls import path
 
-from users.views import SignupView, SigninView, UserMyPageView, VerificationView, SuperadminView
+from users.views import SignupView, SigninView, UserMyPageView, VerificationView, SuperAdminView, SuperAdminModifyView
 
 urlpatterns = [
     path('/mypage', UserMyPageView.as_view()),
     path("/signin", SigninView.as_view()),
     path("/signup", SignupView.as_view()),
     path("/verification", VerificationView.as_view()),
-    path('/admins', SuperadminView.as_view()),
-    path('/admin/<int:user_id>', SuperadminView.as_view()),
+    path('/admins', SuperAdminView.as_view()),
+    path('/admin/<int:user_id>', SuperAdminModifyView.as_view()),
 ]

--- a/users/urls.py
+++ b/users/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path("/signup", SignupView.as_view()),
     path("/verification", VerificationView.as_view()),
     path('/admins', SuperadminView.as_view()),
+    path('/admin/<int:user_id>', SuperadminView.as_view()),
 ]

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from users.views import SignupView, SigninView, UserMyPageView, VerificationView
+from users.views import SignupView, SigninView, UserMyPageView, VerificationView, SuperadminView
 
 urlpatterns = [
     path('/mypage', UserMyPageView.as_view()),
     path("/signin", SigninView.as_view()),
     path("/signup", SignupView.as_view()),
     path("/verification", VerificationView.as_view()),
+    path('/admins', SuperadminView.as_view()),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -281,7 +281,7 @@ class SuperAdminView(APIView):
             "400": "BAD_REQUEST",
             "401": "INVALID_TOKEN"
         },
-        operation_id = "어드민 정보 조회",
+        operation_id = "(슈퍼관리자 전용)어드민 정보 조회",
         operation_description = "header에 토큰이 필요합니다."
     )
     @superadmin_only
@@ -307,7 +307,7 @@ class SuperAdminView(APIView):
             "400": "BAD_REQUEST",
             "401": "INVALID_TOKEN"
         },
-        operation_id = "어드민 생성",
+        operation_id = "(슈퍼관리자 전용)어드민 생성",
         operation_description = "header에 토큰, body에 이메일, 비밀번호 값이 필요합니다, 이메일(abc@def.com 등의 이메일 형식), 패스워드(영문, 숫자, 특수기호) validation이 적용되어 있습니다."
     )
 
@@ -361,7 +361,7 @@ class SuperAdminModifyView(APIView):
             "400": "BAD_REQUEST",
             "401": "INVALID_TOKEN"
         },
-        operation_id = "어드민 정보 수정",
+        operation_id = "(슈퍼관리자 전용)어드민 정보 수정",
         operation_description = "header에 토큰, body에 수정 값이 필요합니다."
     )
     @superadmin_only
@@ -396,7 +396,7 @@ class SuperAdminModifyView(APIView):
             "400": "BAD_REQUEST",
             "401": "INVALID_TOKEN"
         },
-        operation_id = "어드민 삭제",
+        operation_id = "(슈퍼관리자 전용)어드민 삭제",
         operation_description = "header에 토큰값이 필요합니다."
     )
     @superadmin_only


### PR DESCRIPTION
**Description**
필수 리뷰어: 

---
# 진행 배경
## 작업 목표
- 슈퍼어드민 데코레이터 추가
- 슈퍼어드민의 어드민 리스트 보기, 삭제 및 비밀번호 수정 기능
- 슈퍼어드민의 어드민 추가 기능
- URI 정리
---

# 결과
## 변경 후
- 로그인 시 리쿠르트아이디(채용공고) 선택적으로 받는 것으로 수정
---

# 어려웠던 점
-  urls.py를 path('/admins', SuperadminView.as_view()),
                    path('/admin/<int:user_id>', SuperadminView.as_view()), 이렇게 작성해서
   get일때는 admins로 연결되고 patch, delete는 admin/{user_id}로 연결되도록 하고싶었는데 swagger에서는 아래와 같이 중복으로 나타나게 됩니다. 사용하지 않는 리스트를 삭제하거나 API를 잘 정리할 수 있는 방법이 있을까요?
<img width="1397" alt="Screen Shot 2021-09-06 at 6 42 41 PM" src="https://user-images.githubusercontent.com/8315252/132196717-4d9959af-c2f9-4f31-8099-0d25aa43f280.png">

09.08 => 뷰를 SuperAdminView : get, post / SuperAdminModifyView: patch, delete로 나눠서 정리했습니다.
<img width="1402" alt="Screen Shot 2021-09-08 at 11 42 09 AM" src="https://user-images.githubusercontent.com/8315252/132437980-60091e30-db3e-4c47-8f62-b0e3bb904022.png">

# 레퍼런스
- 내용, 실행 방법 및 확인 방법
---
# 기타
- 내용
