### PR TITLE
Add : 어드민페이지 상단 대시보드

### DIFF
--- a/recruits/urls.py
+++ b/recruits/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
 from applications.views import ApplicationView
-from recruits.views     import RecruitListView, RecruitView
+from recruits.views     import RecruitListView, RecruitView, AdminPageView
 
 urlpatterns = [
     path('', RecruitListView.as_view()),
     path('/<int:recruit_id>', RecruitView.as_view()),
     path('/<int:recruit_id>/applications', ApplicationView.as_view()),
+    path('/admin', AdminPageView.as_view())
 ]

--- a/recruits/urls.py
+++ b/recruits/urls.py
@@ -1,11 +1,11 @@
 from django.urls import path
 
 from applications.views import ApplicationView
-from recruits.views     import RecruitListView, RecruitView, AdminPageView
+from recruits.views     import RecruitListView, RecruitView, AdmipageDashboardView
 
 urlpatterns = [
     path('', RecruitListView.as_view()),
     path('/<int:recruit_id>', RecruitView.as_view()),
     path('/<int:recruit_id>/applications', ApplicationView.as_view()),
-    path('/admin', AdminPageView.as_view())
+    path('/admin/dashboard', AdmipageDashboardView.as_view())
 ]


### PR DESCRIPTION
**Description**
필수 리뷰어: 

---
# 진행 배경
## 작업 목표
- 내용
- 어드민페이지 상단 대시보드의 데이터를 구현했습니다.
---

# 결과
## 변경 후
- 내용
--- 어드민페이지의 대시보드 상의 데이터를 숫자로 프론트단에 보내줍니다.

# 어려웠던 점
- 내용
--- 오늘의 지원자를 불러오는데 있어, RecruitView에서 작업을 하다보니 데이터를 어떻게 불러와야 할지 고민이 됐습니다.

# 레퍼런스
- 내용, 실행 방법 및 확인 방법
---
# 기타
- 내용
