### PR TITLE
Update(recruit): 기획에 따라 채용공고 생성에서 모집인원과 연봉 삭제

### DIFF
--- a/applications/urls.py
+++ b/applications/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from applications.views import ApplicationAdminView, ApplicationAdminDetailView,CommentAdminView,CommentAdminModifyView
+from applications.views import ApplicationAdminView, ApplicationView, ApplicationAdminDetailView,CommentAdminView,CommentAdminModifyView
 
 urlpatterns = [
     path('', ApplicationAdminView.as_view()),
+    path('/<int:recruit_id>/applications', ApplicationView.as_view()),
     path('/<int:application_id>', ApplicationAdminDetailView.as_view()),
     path('/<int:application_id>/comments', CommentAdminView.as_view()),
     path('/<int:application_id>/comment/<int:comment_id>', CommentAdminModifyView.as_view()),

--- a/recruits/serializers.py
+++ b/recruits/serializers.py
@@ -7,20 +7,15 @@ class RecruitSerializer(serializers.ModelSerializer):
     class Meta:
         model  = Recruit
         fields = ['position', 'position_title', 'description', 'created_at', 'updated_at', 
-                  'stacks', 'career_type', 'work_type', 'author', 'job_openings','deadline', 'minimum_salary', 'maximum_salary']
+                  'stacks', 'career_type', 'work_type', 'author','deadline']
 
 class RecruitCreateBodySerializer(serializers.Serializer):
     position       = serializers.CharField()
     position_title = serializers.CharField()
     description    = serializers.CharField()
-    stacks         = serializers.ListField()
-    job_openings   = serializers.CharField()
     work_type      = serializers.CharField()
     career_type    = serializers.ChoiceField(choices=("신입", "경력", "신입/경력"), default="신입/경력")
     deadline       = serializers.DateField(default="9999-12-31")
-    minimum_salary = serializers.DecimalField(max_digits=13, decimal_places=2, default=0)
-    maximum_salary = serializers.DecimalField(max_digits=13, decimal_places=2, default=0)
-    
 
 class RecruitQuerySerializer(serializers.Serializer):
     position_title = serializers.CharField(allow_blank=True, allow_null=True, default="")

--- a/recruits/urls.py
+++ b/recruits/urls.py
@@ -7,7 +7,6 @@ from recruits.views     import RecruitListView, RecruitView, AdmipageDashboardVi
 urlpatterns = [
     path('', RecruitListView.as_view()),
     path('/<int:recruit_id>', RecruitView.as_view()),
-    path('/<int:recruit_id>/applications', ApplicationView.as_view()),
     path('/admin/recruit-list', AdminPageRecruitView.as_view()),
     path('/recruit-list-admin',AdminRecruitListView.as_view()),
     path('/admin/dashboard', AdmipageDashboardView.as_view()),

--- a/recruits/views.py
+++ b/recruits/views.py
@@ -98,7 +98,7 @@ class RecruitListView(APIView):
             career_type    = data["career_type"] if data["career_type"] else "신입/경력"
             deadline       = data["deadline"]
 
-            author = request.user.email
+            author = request.user.name if request.user.name else request.user.email.split('@')[0]
 
             if not (career_type in career_type_choices):
                 return JsonResponse({"message": "INVALID_CAREER_TYPE"}, status=400)

--- a/recruits/views.py
+++ b/recruits/views.py
@@ -57,13 +57,10 @@ class RecruitListView(APIView):
                 "id"             : recruit.id,
                 "position"       : recruit.position,
                 "position_title" : recruit.position_title,
-                "work_type"      : recruit.work_type,
                 "career_type"    : recruit.get_career_type_display(),
+                "work_type"      : recruit.work_type,
                 "author"         : recruit.author,
-                "job_openings"   : recruit.job_openings,
                 "description"    : recruit.description,
-                "minimum_salary" : recruit.minimum_salary,
-                "maximum_salary" : recruit.maximum_salary,
                 "deadline"       : recruit.deadline,
                 "created_at"     : recruit.created_at,
                 "updated_at"     : recruit.updated_at,
@@ -82,7 +79,7 @@ class RecruitListView(APIView):
             "401": "UNAUTHORIZED"
         },
         operation_id = "채용공고 생성",
-        operation_description = "포지션, 설명, 기술스택, 근무타입(정규직/계약직), 경력타입(신입or경력or신입/경력), 채용인원, 모집마감일, 최소/최대 연봉을 body에 담아 보내주세요."
+        operation_description = "포지션(develop, design, marketing), 설명, 근무타입(정규직/계약직), 경력타입(신입or경력or신입/경력), 모집마감일을 body에 담아 보내주세요."
     )
     @admin_only
     def post(self, request):
@@ -90,50 +87,31 @@ class RecruitListView(APIView):
             career_type_choices = {
                 "신입": "N",
                 "경력": "C",
-                "신입/경력": "NC",
+                "신입/경력": "NC"
             }
 
             data           = json.loads(request.body)
             position       = data["position"]
             position_title = data["position_title"]
             description    = data["description"]
-            stack_names    = data["stacks"]
-            job_openings   = data["job_openings"]
             work_type      = data["work_type"]
             career_type    = data["career_type"] if data["career_type"] else "신입/경력"
             deadline       = data["deadline"]
-            minimum_salary = data["minimum_salary"]
-            maximum_salary = data["maximum_salary"]
 
             author = request.user.email
 
             if not (career_type in career_type_choices):
                 return JsonResponse({"message": "INVALID_CAREER_TYPE"}, status=400)
 
-            stacks = []
-            
-            for stack_name in stack_names:
-                s = hashlib.sha3_256()
-                s.update(stack_name.encode())
-                hash_id = s.hexdigest()
-
-                object, is_created = Stack.objects.get_or_create(hash_id=hash_id, name=stack_name)
-                stacks.append(object)
-
-            
-            recruit = Recruit.objects.create(
+            Recruit.objects.create(
                 position       = position,
                 position_title = position_title,
                 description    = description,
                 work_type      = work_type,
                 career_type    = career_type_choices[career_type],
-                job_openings   = job_openings,
                 author         = author,
-                deadline       = deadline if deadline else "9999-12-31",
-                minimum_salary = minimum_salary if minimum_salary else 0,
-                maximum_salary = maximum_salary if maximum_salary else 0
+                deadline       = deadline if deadline else "9999-12-31"
             )
-            recruit.stacks.add(*stacks)
 
             return JsonResponse({"message": "SUCCESS"}, status=201)
 

--- a/users/views.py
+++ b/users/views.py
@@ -335,7 +335,6 @@ class SuperAdminView(APIView):
                 email    = data['email'],
                 password = hashed_password.decode('utf-8'),
                 role     = 'admin',
-                # username = data.get('name') if data.get('name') else email.split('@')[0]
                 name = data['username'],
             )
 

--- a/users/views.py
+++ b/users/views.py
@@ -9,7 +9,7 @@ from rest_framework.views import APIView
 from sendgrid.helpers.mail import *
 
 from core.decorators   import login_required, admin_only, superadmin_only
-from global_variable   import SECRET_KEY, ALGORITHM, SENDGRID_API_KEY, EMAIL_DOMAIN
+from global_variable   import SECRET_KEY, ALGORITHM, SENDGRID_API_KEY, EMAIL_DOMAIN, ADMIN_TOKEN
 from users.models      import User, UserTemp
 from recruits.models   import Recruit
 from users.validation  import validate_email, validate_password
@@ -90,7 +90,7 @@ class SigninView(APIView):
             access_token = jwt.encode({'user_id': user.id, 'role': user.role}, SECRET_KEY, ALGORITHM)
             user_name  = user.name if user.name else email.split('@')[0]
 
-            return JsonResponse({'access_token': access_token, 'is_applied': None, 'user_name' : user_name}, status=200)
+            return JsonResponse({'access_token': access_token, 'is_applied': None, 'user_name' : user_name, 'role': user.role}, status=200)
         
         encoded_password = password.encode('utf-8')
         hashed_password  = user.password.encode('utf-8')
@@ -100,7 +100,7 @@ class SigninView(APIView):
             is_applied = Recruit.objects.get(id=recruit_id).applications.filter(user=user).exists() if recruit_id else None
             user_name  = user.name if user.name else email.split('@')[0]
 
-            return JsonResponse({'access_token': access_token, 'is_applied': is_applied, 'user_name' : user_name}, status=200)
+            return JsonResponse({'access_token': access_token, 'is_applied': is_applied, 'user_name' : user_name, 'role': user.role}, status=200)
 
         return JsonResponse({'message': 'INVALID_PASSWORD'}, status=400)            
 
@@ -272,7 +272,8 @@ class SuperAdminView(APIView):
                                         "Authorization", 
                                         openapi.IN_HEADER, 
                                         description = "access_token", 
-                                        type        = openapi.TYPE_STRING
+                                        type        = openapi.TYPE_STRING,
+                                        default     = ADMIN_TOKEN
     )
 
     supaeradmin_get_response = openapi.Response("result", SuperadminGetSerializer)
@@ -293,7 +294,7 @@ class SuperAdminView(APIView):
         result = [{
             "id"        : admin.id,
             "email"     : admin.email,
-            "name"      : admin.name if admin.name else admin.email.split('@')[0],
+            "username"  : admin.name if admin.name else admin.email.split('@')[0],
             "created_at": admin.created_at,
             "updated_at": admin.updated_at,
             "password"  : '********'
@@ -334,7 +335,8 @@ class SuperAdminView(APIView):
                 email    = data['email'],
                 password = hashed_password.decode('utf-8'),
                 role     = 'admin',
-                name     = data.get('name') if data.get('name') else email.split('@')[0]
+                # username = data.get('name') if data.get('name') else email.split('@')[0]
+                name = data['username'],
             )
 
             return JsonResponse({"message": "SUCCESS"}, status=200)
@@ -347,7 +349,8 @@ class SuperAdminModifyView(APIView):
                                         "Authorization", 
                                         openapi.IN_HEADER, 
                                         description = "access_token", 
-                                        type        = openapi.TYPE_STRING
+                                        type        = openapi.TYPE_STRING,
+                                        default     = ADMIN_TOKEN
     )
 
     @swagger_auto_schema (


### PR DESCRIPTION
**Description**
필수 리뷰어:

---
# 진행 배경
## 작업 목표
- 채용공고 생성 페이지를 기획에 맞게 수정(텍스트 에디터 추가, 몇가지 정보 삭제(모집인원, 최저/최고연봉 등) 
<img width="727" alt="Screen Shot 2021-09-28 at 11 37 15 AM" src="https://user-images.githubusercontent.com/8315252/135013415-dbfcac89-5196-4688-8a22-7f1d19360d5e.png">
---

# 결과
## 변경 후
- 프론트와 연결해서 작동

- (users)유저 이름, 권한 관련 변수 수정 및 추가
- (recruits)게시자 이름 부분 수정
---

# 어려웠던 점
- stack을 추가하는 코드를 지워도 되는지 모르겠음
<img width="1211" alt="Screen Shot 2021-09-28 at 11 32 42 AM" src="https://user-images.githubusercontent.com/8315252/135013229-5838256a-6527-42f9-bbb4-d3bd16fa96d8.png">
---

# 레퍼런스
- 내용, 실행 방법 및 확인 방법
---
# 기타
- 내용
