### PR TITLE
Add: 지원서 작성시 필수 데이터 빈값 에러 반환

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -149,6 +149,9 @@ class ApplicationView(APIView):
             )
             application.recruits.add(recruit)
             
+            if '' == (application.content['career'][0]['leavingDate'] and application.content['career'][0]['joinDate']) and application.content['basicInfo']['phoneNumber']:
+                return JsonResponse ({"message":"DATA_NULL"}, status=400)    
+
             Attachment.objects.create(
                 file_url    = file_url,
                 application = application

--- a/applications/views.py
+++ b/applications/views.py
@@ -150,7 +150,7 @@ class ApplicationView(APIView):
             application.recruits.add(recruit)
             
             if '' == (application.content['career'][0]['leavingDate'] and application.content['career'][0]['joinDate']) and application.content['basicInfo']['phoneNumber']:
-                return JsonResponse ({"message":"DATA_NULL"}, status=400)    
+                return JsonResponse ({"message":"DATA_NOT_FOUND"}, status=404)    
 
             Attachment.objects.create(
                 file_url    = file_url,


### PR DESCRIPTION
**Description**
필수 리뷰어:

---
# 진행 배경
## 작업 목표
-  지원서 작성시 입사일/퇴사일/휴대폰번호 빈값일시 에러 반환
---

# 결과
## 변경 후
- 빈값으로 데이터 들어올 경우 DATA_NOT_FOUND, 404 에러 생성
---

# 어려웠던 점
- 내용
- content안에 들어가는 데이터가 빈값이어도, 숫자여도 string 형태로 반환되는데, 올바르지 않은 데이터의 형태가 들어온 에러의 경우는 프론트에서 처리해주어야 할까요?
(날짜에 글자데이터가 들어가는 경우, 숫자데이터에 글자데이터가 들어가는 경우 등등)
--

# 레퍼런스
- 내용, 실행 방법 및 확인 방법
- ---
# 기타
- 내용
